### PR TITLE
Show how to disable chunked transfer encoding in Go and Java server examples

### DIFF
--- a/http/get_simple/go/client/go.mod
+++ b/http/get_simple/go/client/go.mod
@@ -2,7 +2,7 @@ module client
 
 go 1.21.5
 
-require github.com/apache/arrow/go/v15 v15.0.0
+require github.com/apache/arrow/go/v15 v15.0.1
 
 require (
 	github.com/goccy/go-json v0.10.2 // indirect

--- a/http/get_simple/go/server/go.mod
+++ b/http/get_simple/go/server/go.mod
@@ -2,7 +2,7 @@ module server
 
 go 1.21.5
 
-require github.com/apache/arrow/go/v15 v15.0.0
+require github.com/apache/arrow/go/v15 v15.0.1
 
 require (
 	github.com/goccy/go-json v0.10.2 // indirect

--- a/http/get_simple/go/server/server.go
+++ b/http/get_simple/go/server/server.go
@@ -97,11 +97,11 @@ func main() {
 
 		// set these headers if testing with a local browser-based client:
 
-		//hdrs.Add("access-control-allow-origin", "http://localhost:8000")
-		//hdrs.Add("access-control-allow-methods", "GET")
-		//hdrs.Add("access-control-allow-headers", "content-type")
+		//hdrs.Add("Access-Control-Allow-Origin", "http://localhost:8000")
+		//hdrs.Add("Access-Control-Allow-Methods", "GET")
+		//hdrs.Add("Access-Control-Allow-Headers", "content-type")
 
-		hdrs.Add("content-type", "application/vnd.apache.arrow.stream")
+		hdrs.Add("Content-Type", "application/vnd.apache.arrow.stream")
 		w.WriteHeader(http.StatusOK)
 
 		wr := ipc.NewWriter(w, ipc.WithSchema(batches[0].Schema()))

--- a/http/get_simple/go/server/server.go
+++ b/http/get_simple/go/server/server.go
@@ -95,8 +95,10 @@ func main() {
 
 		hdrs := w.Header()
 
-		// set these headers if testing with a local browser-based client:
+		//// set this header to disable chunked transfer encoding:
+		//hdrs.Add("Transfer-Encoding", "identity")
 
+		//// set these headers if testing with a local browser-based client:
 		//hdrs.Add("Access-Control-Allow-Origin", "http://localhost:8000")
 		//hdrs.Add("Access-Control-Allow-Methods", "GET")
 		//hdrs.Add("Access-Control-Allow-Headers", "content-type")

--- a/http/get_simple/java/server/src/main/java/com/example/ArrowHttpServer.java
+++ b/http/get_simple/java/server/src/main/java/com/example/ArrowHttpServer.java
@@ -118,6 +118,11 @@ public class ArrowHttpServer extends AbstractHandler {
         response.setContentType("application/vnd.apache.arrow.stream");
         response.setStatus(HttpServletResponse.SC_OK);
 
+        //// set this header to disable chunked transfer encoding:
+        //response.setHeader("Connection", "close");
+        
+        response.flushBuffer();
+
         try (
             OutputStream stream = response.getOutputStream();
             VectorSchemaRoot root = VectorSchemaRoot.create(schema, allocator);


### PR DESCRIPTION
I was looking at the raw output from the different server examples by running
```sh
curl -v --raw -o output.raw http://localhost:8000
```
and examining `output.raw` with a hex viewer, and I noticed that the Go server example (using [http](https://pkg.go.dev/net/http)) and the Java server example (using [Jetty](https://eclipse.dev/jetty/)) both use [chunked transfer encoding](https://en.wikipedia.org/wiki/Chunked_transfer_encoding) by default when the `Content-Length` header is not set, whereas the Python server example (using [http.server](https://docs.python.org/3/library/http.server.html)) and the Rust server example in #8 (which doesn't use any high-level HTTP framework) do not.

I added comments in both examples showing how to disable chunked transfer encoding.