### PR TITLE
Change port number to 8008

### DIFF
--- a/http/get_simple/c_glib/client/client.c
+++ b/http/get_simple/c_glib/client/client.c
@@ -29,7 +29,7 @@ main(int argc, char **argv)
 
   SoupSession *session = soup_session_new();
   SoupMessage *message = soup_message_new(SOUP_METHOD_GET,
-                                          "http://localhost:8000");
+                                          "http://localhost:8008");
 
   GTimer *timer = g_timer_new();
 

--- a/http/get_simple/cpp/client/client.cpp
+++ b/http/get_simple/cpp/client/client.cpp
@@ -35,7 +35,7 @@ WriteFunction(void *contents, size_t size, size_t nmemb, void *userp)
 
 int main(void)
 {
-  std::string url = "http://localhost:8000";
+  std::string url = "http://localhost:8008";
 
   CURL *curl_handle;
   CURLcode res;

--- a/http/get_simple/go/client/client.go
+++ b/http/get_simple/go/client/client.go
@@ -28,7 +28,7 @@ import (
 
 func main() {
 	start := time.Now()
-	resp, err := http.Get("http://localhost:8000")
+	resp, err := http.Get("http://localhost:8008")
 	if err != nil {
 		panic(err)
 	}

--- a/http/get_simple/go/server/server.go
+++ b/http/get_simple/go/server/server.go
@@ -99,7 +99,7 @@ func main() {
 		//hdrs.Add("Transfer-Encoding", "identity")
 
 		//// set these headers if testing with a local browser-based client:
-		//hdrs.Add("Access-Control-Allow-Origin", "http://localhost:8000")
+		//hdrs.Add("Access-Control-Allow-Origin", "http://localhost:8008")
 		//hdrs.Add("Access-Control-Allow-Methods", "GET")
 		//hdrs.Add("Access-Control-Allow-Headers", "content-type")
 
@@ -116,6 +116,6 @@ func main() {
 		}
 	})
 
-	fmt.Println("Serving on localhost:8000...")
-	log.Fatal(http.ListenAndServe(":8000", nil))
+	fmt.Println("Serving on localhost:8008...")
+	log.Fatal(http.ListenAndServe(":8008", nil))
 }

--- a/http/get_simple/java/client/src/main/java/com/example/ArrowHttpClient.java
+++ b/http/get_simple/java/client/src/main/java/com/example/ArrowHttpClient.java
@@ -32,7 +32,7 @@ import java.util.ArrayList;
 public class ArrowHttpClient {
 
     public static void main(String[] args) {
-        String serverUrl = "http://localhost:8000";
+        String serverUrl = "http://localhost:8008";
 
         try {
             long startTime = System.currentTimeMillis();

--- a/http/get_simple/java/server/src/main/java/com/example/ArrowHttpServer.java
+++ b/http/get_simple/java/server/src/main/java/com/example/ArrowHttpServer.java
@@ -143,10 +143,10 @@ public class ArrowHttpServer extends AbstractHandler {
     public static void main(String[] args) throws Exception {
         batches = getPutData();
 
-        Server server = new Server(8000);
+        Server server = new Server(8008);
         server.setHandler(new ArrowHttpServer());
         server.start();
-        System.out.println("Serving on localhost:8000...");
+        System.out.println("Serving on localhost:8008...");
         server.join();
     }
     

--- a/http/get_simple/js/client/client.js
+++ b/http/get_simple/js/client/client.js
@@ -17,7 +17,7 @@
 
 const Arrow = require('apache-arrow');
 
-const url = 'http://localhost:8000';
+const url = 'http://localhost:8008';
 
 async function runExample(url) {
   const startTime = new Date();

--- a/http/get_simple/python/client/client.py
+++ b/http/get_simple/python/client/client.py
@@ -21,7 +21,7 @@ import time
 
 start_time = time.time()
 
-with urllib.request.urlopen('http://localhost:8000') as response:
+with urllib.request.urlopen('http://localhost:8008') as response:
   buffer = response.read()
 
 batches = []

--- a/http/get_simple/python/server/server.py
+++ b/http/get_simple/python/server/server.py
@@ -87,7 +87,7 @@ class MyServer(BaseHTTPRequestHandler):
         self.send_header('Content-Type', 'application/vnd.apache.arrow.stream')
         
         ### set these headers if testing with a local browser-based client:
-        #self.send_header('Access-Control-Allow-Origin', 'http://localhost:8000')
+        #self.send_header('Access-Control-Allow-Origin', 'http://localhost:8008')
         #self.send_header('Access-Control-Allow-Methods', 'GET')
         #self.send_header('Access-Control-Allow-Headers', 'Content-Type')
         
@@ -134,7 +134,7 @@ class MyServer(BaseHTTPRequestHandler):
 
 batches = GetPutData()
 
-server_address = ('localhost', 8000)
+server_address = ('localhost', 8008)
 try:
     httpd = HTTPServer(server_address, MyServer)
     print(f'Serving on {server_address[0]}:{server_address[1]}...')

--- a/http/get_simple/r/client/client.R
+++ b/http/get_simple/r/client/client.R
@@ -19,7 +19,7 @@ library(httr)
 library(tictoc)
 suppressPackageStartupMessages(library(arrow))
 
-url <- 'http://localhost:8000'
+url <- 'http://localhost:8008'
 
 tic()
 

--- a/http/get_simple/rs/client/src/main.rs
+++ b/http/get_simple/rs/client/src/main.rs
@@ -31,7 +31,7 @@ fn main() {
 
     info_span!("get_simple").in_scope(|| {
         // Connect to server.
-        let addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 8000);
+        let addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 8008);
         match TcpStream::connect(addr) {
             Ok(mut stream) => {
                 info_span!("Reading Arrow IPC stream", %addr).in_scope(|| {

--- a/http/get_simple/rs/server/src/main.rs
+++ b/http/get_simple/rs/server/src/main.rs
@@ -114,7 +114,7 @@ fn main() -> Result<()> {
     let _ = Lazy::force(&DATA);
 
     // Start listening.
-    let bind_addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 8000);
+    let bind_addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 8008);
     let listener = TcpListener::bind(bind_addr)?;
     info!(%bind_addr, "Listening");
 


### PR DESCRIPTION
The HTTP examples use port 8000, but [officially](https://www.iana.org/assignments/service-names-port-numbers/service-names-port-numbers.xhtml?search=http-alt) IANA assigns ports 591, 8008, and 8080 as HTTP alternate ports and assigns port 8000 for something else. This switches the examples to use 8008.