### PR TITLE
c_glib: Disable keep-alive for stable result with Ruby server

### DIFF
--- a/http/get_simple/c_glib/client/client.c
+++ b/http/get_simple/c_glib/client/client.c
@@ -33,7 +33,7 @@ main(int argc, char **argv)
   /* Disable keep-alive explicitly. (libsoup uses keep-alive by
    * default.)
    *
-   * In general, keep-alive will improve performance when we sends
+   * In general, keep-alive will improve performance when we send
    * many GET requests to the same server. But in this case, we send
    * only one GET request. So we don't need keep-alive here.
    */

--- a/http/get_simple/c_glib/client/client.c
+++ b/http/get_simple/c_glib/client/client.c
@@ -30,6 +30,15 @@ main(int argc, char **argv)
   SoupSession *session = soup_session_new();
   SoupMessage *message = soup_message_new(SOUP_METHOD_GET,
                                           "http://localhost:8008");
+  /* Disable keep-alive explicitly. (libsoup uses keep-alive by
+   * default.)
+   *
+   * In general, keep-alive will improve performance when we sends
+   * many GET requests to the same server. But in this case, we send
+   * only one GET request. So we don't need keep-alive here.
+   */
+  SoupMessageHeaders *headers = soup_message_get_request_headers(message);
+  soup_message_headers_append(headers, "connection", "close");
 
   GTimer *timer = g_timer_new();
 


### PR DESCRIPTION
This is for suppressing needless error message with Ruby server.

See also:
* https://github.com/apache/arrow-experiments/pull/17#issuecomment-1991629068
* https://github.com/apache/arrow-experiments/pull/17#issuecomment-1993628546