### PR TITLE
http/python: Simplify server.py and reduce client processing time in half

### DIFF
--- a/http/get_simple/python/client/client.py
+++ b/http/get_simple/python/client/client.py
@@ -21,12 +21,11 @@ import time
 
 start_time = time.time()
 
-with urllib.request.urlopen('http://localhost:8008') as response:
-  buffer = response.read()
+response = urllib.request.urlopen('http://localhost:8008')
 
 batches = []
 
-with pa.ipc.open_stream(buffer) as reader:
+with pa.ipc.open_stream(response) as reader:
   schema = reader.schema
   try:
     while True:
@@ -35,13 +34,12 @@ with pa.ipc.open_stream(buffer) as reader:
       pass
 
 # or:
-#with pa.ipc.open_stream(buffer) as reader:
+#with pa.ipc.open_stream(response) as reader:
 #  schema = reader.schema
 #  batches = [b for b in reader]
 
 end_time = time.time()
 execution_time = end_time - start_time
 
-print(f"{len(buffer)} bytes received")
 print(f"{len(batches)} record batches received")
 print(f"{execution_time} seconds elapsed")

--- a/http/get_simple/python/client/client.py
+++ b/http/get_simple/python/client/client.py
@@ -19,9 +19,14 @@ import urllib.request
 import pyarrow as pa
 import time
 
+ARROW_STREAM_FORMAT = 'application/vnd.apache.arrow.stream'
+
 start_time = time.time()
 
 response = urllib.request.urlopen('http://localhost:8008')
+content_type = response.headers['Content-Type']
+if content_type != ARROW_STREAM_FORMAT:
+  raise ValueError(f"Expected {ARROW_STREAM_FORMAT}, got {content_type}")
 
 batches = []
 

--- a/http/get_simple/python/server/server.py
+++ b/http/get_simple/python/server/server.py
@@ -62,29 +62,33 @@ def generate_buffers(schema, source):
             sink.seek(0)
             writer.write_batch(batch)
             sink.truncate()
-            yield sink.getvalue()
+            with sink.getbuffer() as buffer:
+                yield buffer
         
         sink.seek(0)
         writer.close()
         sink.truncate()
-        yield sink.getvalue()
+        with sink.getbuffer() as buffer:
+            yield buffer
 
-# def chunk_huge_buffer(buffer, max_chunk_size):
-#     view = memoryview(buffer)
+# def chunk_huge_buffer(view, max_chunk_size):
 #     if len(view) <= max_chunk_size:
 #         yield view
 #         return
 #     num_splits = len(view) // max_chunk_size
 #     for i in range(num_splits):
-#         yield view[i * max_chunk_size:i * max_chunk_size + max_chunk_size]
+#         with view[i * max_chunk_size:i * max_chunk_size + max_chunk_size] as chunk:
+#             yield chunk
 #     last_chunk_size = len(view) - (num_splits * max_chunk_size)
 #     if last_chunk_size > 0:
-#         yield view[num_splits * max_chunk_size:]
+#         with view[num_splits * max_chunk_size:] as chunk:
+#             yield chunk
 
 # def generate_chunked_buffers(schema, source, max_chunk_size):
 #     for buffer in generate_buffers(schema, source):
-#         for chunk in chunk_huge_buffer(buffer, max_chunk_size):
-#             yield chunk
+#         with memoryview(buffer) as view:
+#             for chunk in chunk_huge_buffer(view, max_chunk_size):
+#                 yield chunk
  
 class MyServer(BaseHTTPRequestHandler):
     def resolve_batches(self):

--- a/http/get_simple/python/server/server.py
+++ b/http/get_simple/python/server/server.py
@@ -60,13 +60,13 @@ def generate_buffers(schema, source):
     with io.BytesIO() as sink, pa.ipc.new_stream(sink, schema) as writer:
         for batch in source:
             sink.seek(0)
-            sink.truncate(0)
             writer.write_batch(batch)
+            sink.truncate()
             yield sink.getvalue()
         
         sink.seek(0)
-        sink.truncate(0)
         writer.close()
+        sink.truncate()
         yield sink.getvalue()
  
 class MyServer(BaseHTTPRequestHandler):


### PR DESCRIPTION
`response` is a file-like Python object, and as such it's not necessary to
allocate the entire buffer before creating the IPC stream.

This reduced the elapsed time in half while handling a 3GB response
generated by `server.py`: from 1.108s to 0.638s on my machine.