### PR TITLE
http: Improve curl example readme

### DIFF
--- a/http/get_simple/curl/client/README.md
+++ b/http/get_simple/curl/client/README.md
@@ -36,7 +36,7 @@ To read the resulting file `output.arrows` and retrieve the schema and record ba
   ```py
   import pyarrow as pa
 
-  with open("output.arrows") as f:
+  with open("output.arrows", "rb") as f:
       reader = pa.ipc.open_stream(f)
       
       schema = reader.schema

--- a/http/get_simple/curl/client/README.md
+++ b/http/get_simple/curl/client/README.md
@@ -36,7 +36,7 @@ To read the resulting file `output.arrows` and retrieve the schema and record ba
   ```py
   import pyarrow as pa
 
-  with open("output.arrows", "rb") as f:
+  with open("output.arrows") as f:
       reader = pa.ipc.open_stream(f)
       
       schema = reader.schema

--- a/http/get_simple/curl/client/README.md
+++ b/http/get_simple/curl/client/README.md
@@ -37,15 +37,15 @@ To read the resulting file `output.arrows` and retrieve the schema and record ba
   import pyarrow as pa
 
   with open("output.arrows", "rb") as f:
-      reader = pa.ipc.open_stream(pa.BufferReader(f.read()))
-
-  schema = reader.schema
-
-  batch = reader.read_next_batch()
-  # ...
-
-  # or alternatively:
-  batches = [b for b in reader]
+      reader = pa.ipc.open_stream(f)
+      
+      schema = reader.schema
+      
+      batch = reader.read_next_batch()
+      # ...
+      
+      # or alternatively:
+      batches = [b for b in reader]
   ```
 </details>
 


### PR DESCRIPTION
This PR simplifies the example showing how to read an Arrow IPC stream file with PyArrow after downloading it with curl.