### PR TITLE
[MATLAB] Add simple HTTP `GET` MATLAB Client example

### DIFF
--- a/http/get_simple/matlab/README.md
+++ b/http/get_simple/matlab/README.md
@@ -29,6 +29,6 @@ To run this example, first start one of the server examples in the parent direct
 
 Run the MATLAB `client` script in "batch mode":
 
-```shell
-$ matlab -batch client
+```sh
+matlab -batch client
 ```

--- a/http/get_simple/matlab/README.md
+++ b/http/get_simple/matlab/README.md
@@ -1,0 +1,40 @@
+<!---
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing,
+  software distributed under the License is distributed on an
+  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  KIND, either express or implied.  See the License for the
+  specific language governing permissions and limitations
+  under the License.
+-->
+
+# HTTP GET Arrow Data: Simple MATLAB Client Example
+
+This directory contains a minimal example of an HTTP client implemented in MATLAB. The client:
+
+1. Sends an HTTP GET request to a server.
+2. Receives an HTTP 200 response from the server, with the response body containing an Arrow IPC stream of record batches.
+3. Creates an Arrow table from the record batches
+
+To run this example, first start one of the server examples in the parent directory, then:
+
+1. Start MATLAB
+
+```shell
+$ matlab
+```
+
+2. Run the MATLAB script `client.m`:
+
+```matlab
+>> client
+```

--- a/http/get_simple/matlab/README.md
+++ b/http/get_simple/matlab/README.md
@@ -27,14 +27,8 @@ This directory contains a minimal example of an HTTP client implemented in MATLA
 
 To run this example, first start one of the server examples in the parent directory, then:
 
-1. Start MATLAB
+Run the MATLAB `client` script in "batch mode":
 
 ```shell
-$ matlab
-```
-
-2. Run the MATLAB script `client.m`:
-
-```matlab
->> client
+$ matlab -batch client
 ```

--- a/http/get_simple/matlab/client.m
+++ b/http/get_simple/matlab/client.m
@@ -50,7 +50,7 @@ disp("DONE ✔");
 disp("---------------");
 disp("Results")
 disp("---------------");
-disp("Time (s): " + string(time));
+disp("Time (s): " + sprintf("%.2f", time));
 disp("Num Bytes: " + string(nbytes));
 disp("Num Rows:" + string(arrowTable.NumRows));
 disp("Num Columns:" + string(arrowTable.NumColumns));

--- a/http/get_simple/matlab/client.m
+++ b/http/get_simple/matlab/client.m
@@ -15,8 +15,8 @@
 % specific language governing permissions and limitations
 % under the License.
 
-% The address of the local HTTP server
-% which returns Arrow IPC Stream responses.
+% The address of the HTTP server that
+% returns Arrow IPC Stream responses.
 server = "http://localhost:8008";
 
 % Diagnostic output.

--- a/http/get_simple/matlab/client.m
+++ b/http/get_simple/matlab/client.m
@@ -1,0 +1,56 @@
+% Licensed to the Apache Software Foundation (ASF) under one
+% or more contributor license agreements.  See the NOTICE file
+% distributed with this work for additional information
+% regarding copyright ownership.  The ASF licenses this file
+% to you under the Apache License, Version 2.0 (the
+% "License"); you may not use this file except in compliance
+% with the License.  You may obtain a copy of the License at
+%
+%   http://www.apache.org/licenses/LICENSE-2.0
+%
+% Unless required by applicable law or agreed to in writing,
+% software distributed under the License is distributed on an
+% "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+% KIND, either express or implied.  See the License for the
+% specific language governing permissions and limitations
+% under the License.
+
+% The address of the local HTTP server
+% which returns Arrow IPC Stream responses.
+server = "http://localhost:8008";
+
+% Diagnostic output.
+disp("Reading Arrow IPC Stream from " + server + "...");
+
+% Start timing.
+tic;
+
+% Make an HTTP GET request to the local server
+% to fetch an Arrow IPC Stream and read all the
+% data into memory as a byte (uint8) array.
+options = weboptions(ContentType="binary");
+bytes = webread(server, options);
+
+% Construct an Arrow RecordBatchStreamReader from the in-memory bytes.
+reader = arrow.io.ipc.RecordBatchStreamReader.fromBytes(bytes);
+
+% Read an Arrow table from the in-memory bytes.
+arrowTable = reader.readTable();
+
+% Stop timing.
+time = toc;
+% Round elapsed time to two decimal places.
+time = round(time, 2);
+
+% Number of bytes received.
+nbytes = length(bytes);
+
+% Diagnostic output.
+disp("DONE ✔");
+disp("---------------");
+disp("Results")
+disp("---------------");
+disp("Time (s): " + string(time));
+disp("Num Bytes: " + string(nbytes));
+disp("Num Rows:" + string(arrowTable.NumRows));
+disp("Num Columns:" + string(arrowTable.NumColumns));


### PR DESCRIPTION
### Overview

Now that the MATLAB interface supports [reading the Arrow IPC Stream format from a byte array (`uint8`)](https://github.com/apache/arrow/pull/45274), we can now easily consume Arrow IPC Streams over HTTP and load them into an `arrow.tabular.Table` in memory.

This PR adds a simple HTTP `GET` MATLAB Client example.

This was tested against the Python server. We would be happy to do more testing as needed.

@ianmcook - would you like to take a look at this PR? Thank you!

### Example Output from `client.m`

```shell
$ matlab -batch client
Reading Arrow IPC Stream from http://localhost:8008...
DONE ✔
---------------
Results
---------------
Time (s): 6.28
Num Bytes: 3207031800
Num Rows:100000000
Num Columns:4
```

### Notes

1. We included fairly detailed comments in the example code for completeness. However, if we prefer to keep the `client.m` script shorter, we are happy to remove these.
2. The average time it takes to run the client in MATLAB (not including MATLAB startup time) is about 5.5-6s. This example isn't particularly well optimized but does work as expected. `README.md` instructs users to run `client` in `-batch` mode which can result in some additional delay due to MATLAB startup. The script should run fine if MATLAB is launched and then the script is executed interactively, as well. We just thought it would be easier to directly run the script in `-batch` mode from the command line.
3. We included some diagnostic output such as number of  bytes received and number of rows. However, if there is more information that we want to include, we are happy to add that.
4. Thanks @sgilmore10 for your help with this pull request!


-----

Closes https://github.com/apache/arrow/issues/40489