### PR TITLE
Add `rand-many-types` data in Parquet and DuckDB formats

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -14,6 +14,7 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+
 data/**/*.arrows filter=lfs diff=lfs merge=lfs -text
 data/**/*.arrow filter=lfs diff=lfs merge=lfs -text
 data/**/*.jsonl filter=lfs diff=lfs merge=lfs -text

--- a/data/rand-many-types/Makefile
+++ b/data/rand-many-types/Makefile
@@ -1,0 +1,27 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+all: arrow parquet duckdb
+
+arrow: generate.py
+	python ./generate.py
+
+parquet: arrow
+	python ./arrows-to-parquet.py
+
+duckdb: parquet
+	duckdb -f ./parquet-to-duckdb.sql

--- a/data/rand-many-types/README.md
+++ b/data/rand-many-types/README.md
@@ -20,3 +20,5 @@
 # rand-many-types
 
 This directory contains a file `random.arrows` in Arrow IPC stream format with randomly generated values in 20+ columns exercising many different Arrow data types. The Python script `generate.py` that generated the data file is included.
+
+The same data is also included as a Parquet file (`random.parquet`) and as a DuckDB database file (`random.duckdb`) as the table named `random`. The Python and SQL used to generate these files is included.

--- a/data/rand-many-types/README.md
+++ b/data/rand-many-types/README.md
@@ -22,3 +22,8 @@
 This directory contains a file `random.arrows` in Arrow IPC stream format with randomly generated values in 20+ columns exercising many different Arrow data types. The Python script `generate.py` that generated the data file is included.
 
 The same data is also included as a Parquet file (`random.parquet`) and as a DuckDB database file (`random.duckdb`) as the table named `random`. The Python and SQL used to generate these files is included.
+
+To re-generate the data files (for example, if you change `generate.py`),
+
+1. Make sure `duckdb` is in your path and activate a Python environment with the packages in `./requirements.txt`
+2. Run `make`

--- a/data/rand-many-types/arrows-to-parquet.py
+++ b/data/rand-many-types/arrows-to-parquet.py
@@ -14,9 +14,13 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-data/**/*.arrows filter=lfs diff=lfs merge=lfs -text
-data/**/*.arrow filter=lfs diff=lfs merge=lfs -text
-data/**/*.jsonl filter=lfs diff=lfs merge=lfs -text
-data/**/*.parquet filter=lfs diff=lfs merge=lfs -text
-data/**/*.db filter=lfs diff=lfs merge=lfs -text
-data/**/*.duckdb filter=lfs diff=lfs merge=lfs -text
+
+import pyarrow as pa
+import pyarrow.parquet as pq
+
+
+with open("random.arrows", "rb") as f:
+    reader = pa.ipc.open_stream(f)
+    table = reader.read_all()
+
+pq.write_table(table, "random.parquet")

--- a/data/rand-many-types/parquet-to-duckdb.sql
+++ b/data/rand-many-types/parquet-to-duckdb.sql
@@ -16,5 +16,6 @@
 -- under the License.
 
 .open random.duckdb
-CREATE TABLE random AS SELECT * FROM 'random.parquet';
+DROP TABLE IF EXISTS random;
+CREATE TABLE random AS SELECT * FROM './random.parquet';
 .exit

--- a/data/rand-many-types/parquet-to-duckdb.sql
+++ b/data/rand-many-types/parquet-to-duckdb.sql
@@ -1,0 +1,19 @@
+-- Licensed to the Apache Software Foundation (ASF) under one
+-- or more contributor license agreements.  See the NOTICE file
+-- distributed with this work for additional information
+-- regarding copyright ownership.  The ASF licenses this file
+-- to you under the Apache License, Version 2.0 (the
+-- "License"); you may not use this file except in compliance
+-- with the License.  You may obtain a copy of the License at
+--
+--   http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing,
+-- software distributed under the License is distributed on an
+-- "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+-- KIND, either express or implied.  See the License for the
+-- specific language governing permissions and limitations
+-- under the License.
+
+.open random.duckdb
+CREATE TABLE random AS SELECT * FROM 'random.parquet';

--- a/data/rand-many-types/parquet-to-duckdb.sql
+++ b/data/rand-many-types/parquet-to-duckdb.sql
@@ -17,3 +17,4 @@
 
 .open random.duckdb
 CREATE TABLE random AS SELECT * FROM 'random.parquet';
+.exit

--- a/data/rand-many-types/random.duckdb
+++ b/data/rand-many-types/random.duckdb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:bde19081ecd2fe1a6d1b9635cb87a82abdddf38040cc5921dd403e45357cd44b
+size 9449472

--- a/data/rand-many-types/random.duckdb
+++ b/data/rand-many-types/random.duckdb
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:bde19081ecd2fe1a6d1b9635cb87a82abdddf38040cc5921dd403e45357cd44b
-size 9449472
+oid sha256:f1f00607e3755773432dc81ba4bfe8bcdae8457f3430587a12d632261c4451fe
+size 17575936

--- a/data/rand-many-types/random.parquet
+++ b/data/rand-many-types/random.parquet
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1518178747ce49b87f13feca3b125f3dcc0c686d198a205c6c8d38c5c4db1158
+size 11109117

--- a/data/rand-many-types/requirements.txt
+++ b/data/rand-many-types/requirements.txt
@@ -1,0 +1,2 @@
+numpy
+pyarrow


### PR DESCRIPTION
This adds copies of the data in `data/rand-many-types` in Parquet file format and DuckDB database file format. The code used to generate these files is included.