### PR TITLE
[data] Add Arrow IPC file

### DIFF
--- a/data/rand-many-types/README.md
+++ b/data/rand-many-types/README.md
@@ -21,7 +21,7 @@
 
 This directory contains a file `random.arrows` in Arrow IPC stream format with randomly generated values in 20+ columns exercising many different Arrow data types. The Python script `generate.py` that generated the data file is included.
 
-The same data is also included as a Parquet file (`random.parquet`) and as a DuckDB database file (`random.duckdb`) as the table named `random`. The Python and SQL used to generate these files is included.
+The same data is also included as a file in Arrow IPC file format (`random.arrow`), as a Parquet file (`random.parquet`), and as a DuckDB database file (`random.duckdb`) as the table named `random`. The Python and SQL used to generate these files is included.
 
 To re-generate the data files (for example, if you change `generate.py`),
 

--- a/data/rand-many-types/arrows-to-arrow.py
+++ b/data/rand-many-types/arrows-to-arrow.py
@@ -15,16 +15,16 @@
 # specific language governing permissions and limitations
 # under the License.
 
-all: arrows arrow parquet duckdb
+import pyarrow as pa
 
-arrows: generate.py
-	python ./generate.py
 
-arrow: arrows
-	python ./arrows-to-arrow.py
-
-parquet: arrows
-	python ./arrows-to-parquet.py
-
-duckdb: parquet
-	duckdb -f ./parquet-to-duckdb.sql
+with (
+    open("random.arrows", "rb") as f,
+    pa.ipc.open_stream(f) as reader,
+    pa.ipc.new_file("random.arrow", reader.schema) as writer
+):
+    while True:
+        try:
+            writer.write_batch(reader.read_next_batch())
+        except StopIteration:
+            break

--- a/data/rand-many-types/random.arrow
+++ b/data/rand-many-types/random.arrow
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6750b23dc41231858f8b2b38a28bb2cb94c767ebfbf5fd6c413f6c1520206718
+size 13554522


### PR DESCRIPTION
For completeness, this adds the Arrow IPC file format to the `rand-many-types` example.